### PR TITLE
Power system - on update rework

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -58,15 +58,6 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             //updateActions(this, deltaTime);
 
-            if (powerValue > 0 && isPowerGenerator == false)
-            {
-                if(World.current.powerSystem.RequestPower(this) == false)
-                {
-                    World.current.powerSystem.RegisterPowerConsumer(this);
-                    return;
-                }
-            }
-
             FurnitureActions.CallFunctionsWithFurniture(updateActions.ToArray(), this, deltaTime);
         }
     }
@@ -365,6 +356,28 @@ public class Furniture : IXmlSerializable, ISelectable
 
         return true;
     }
+
+
+    public bool HasPowerCheck()
+    {
+
+        if (powerValue > 0 && isPowerGenerator == false)
+        {
+            if (World.current.powerSystem.RequestPower(this) == true)
+            {
+                return true;
+            }
+            else
+            {
+                World.current.powerSystem.RegisterPowerConsumer(this);
+                return false;
+            }
+        }
+
+        return false;
+
+    }
+
 
     [MoonSharpVisible(true)]
     private void UpdateOnChanged(Furniture furn)

--- a/Assets/StreamingAssets/LUA/Furniture.lua
+++ b/Assets/StreamingAssets/LUA/Furniture.lua
@@ -17,6 +17,10 @@ end
 
 -------------------------------- Furniture Actions --------------------------------
 function OnUpdate_GasGenerator( furniture, deltaTime )
+	if ( furniture.HasPowerCheck() == false) then
+		return
+	end
+
 	if ( furniture.tile.room == nil ) then
 		return "Furniture's room was null."
 	end


### PR DESCRIPTION
Ok attempt Three! --

I have moved the power system check from the furniture update function to its own function so that it is no longer used by ALL the furniture. This function can instead be used in the Lua code for furniture to check if it has power.

This will allow alternative behaviour to be scripted in Lua for if the furniture has power or not.

Once again the only furniture using this at the moment is the oxygen generator. 